### PR TITLE
[Spark 22361][YARN] Allow AM to restart after initial tokens expire.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -70,7 +70,6 @@ public class TransportClientFactory implements Closeable {
         locks[i] = new Object();
       }
     }
-//    lastConnectionFailed = 0;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(TransportClientFactory.class);
@@ -188,9 +187,7 @@ public class TransportClientFactory implements Closeable {
           logger.info("Found inactive connection to {}, creating a new one.", resolvedAddress);
         }
       }
-      //clientPool.clients[clientIndex] = createClient(resolvedAddress);
-        // If this connection should fast fail when last connection failed in last fast fail time
-      // window and it did, fail this connection directly.
+
       if (fastFail && System.currentTimeMillis() - clientPool.lastConnectionFailed <
         fastFailTimeWindow) {
         throw new IOException(

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -70,7 +70,7 @@ public class TransportClientFactory implements Closeable {
         locks[i] = new Object();
       }
     }
-    lastConnectionFailed = 0;
+//    lastConnectionFailed = 0;
   }
 
   private static final Logger logger = LoggerFactory.getLogger(TransportClientFactory.class);

--- a/common/network-common/src/test/java/org/apache/spark/network/TransportClientFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TransportClientFactorySuite.java
@@ -26,10 +26,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -44,6 +41,7 @@ import org.apache.spark.network.util.ConfigProvider;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.network.util.TransportConf;
+import org.junit.rules.ExpectedException;
 
 public class TransportClientFactorySuite {
   private TransportConf conf;
@@ -215,6 +213,27 @@ public class TransportClientFactorySuite {
       assertFalse(c1.isActive());
     }
   }
+
+@Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void fastFailConnectionInTimeWindow() throws IOException, InterruptedException {
+    TransportClientFactory factory = context.createClientFactory();
+    TransportServer server = context.createServer();
+    int unreachablePort = server.getPort();
+    server.close();
+    try {
+      factory.createClient(TestUtils.getLocalHost(), unreachablePort, true);
+    } catch (Exception e) {
+      assert(e instanceof IOException);
+    }
+    expectedException.expect(IOException.class);
+    expectedException.expectMessage("fail this connection directly");
+    factory.createClient(TestUtils.getLocalHost(), unreachablePort, true);
+    expectedException = ExpectedException.none();
+  }
+
 
   @Test(expected = IOException.class)
   public void closeFactoryBeforeCreateClient() throws IOException, InterruptedException {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -98,13 +98,11 @@ public class ExternalShuffleClient extends ShuffleClient {
       int maxRetries = conf.maxIORetries();
       RetryingBlockFetcher.BlockFetchStarter blockFetchStarter =
           (blockIds1, listener1) -> {
-      //      TransportClient client = clientFactory.createClient(host, port);
          TransportClient client = clientFactory.createClient(host, port, maxRetries > 0);
-		  new OneForOneBlockFetcher(client, appId, execId,
+         new OneForOneBlockFetcher(client, appId, execId,
               blockIds1, listener1, conf, downloadFileManager).start();
           };
 
-      int maxRetries = conf.maxIORetries();
       if (maxRetries > 0) {
         // Note this Fetcher will correctly handle maxRetries == 0; we avoid it just in case there's
         // a bug in this code. We should remove the if statement once we're sure of the stability.

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleClient.java
@@ -95,10 +95,12 @@ public class ExternalShuffleClient extends ShuffleClient {
     checkInit();
     logger.debug("External shuffle fetch from {}:{} (executor id {})", host, port, execId);
     try {
+      int maxRetries = conf.maxIORetries();
       RetryingBlockFetcher.BlockFetchStarter blockFetchStarter =
           (blockIds1, listener1) -> {
-            TransportClient client = clientFactory.createClient(host, port);
-            new OneForOneBlockFetcher(client, appId, execId,
+      //      TransportClient client = clientFactory.createClient(host, port);
+         TransportClient client = clientFactory.createClient(host, port, maxRetries > 0);
+		  new OneForOneBlockFetcher(client, appId, execId,
               blockIds1, listener1, conf, downloadFileManager).start();
           };
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -570,6 +570,7 @@ package object config {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("1g")
 
+
   private[spark] val CREDENTIALS_RENEWAL_INTERVAL_RATIO =
     ConfigBuilder("spark.security.credentials.renewalRatio")
       .doc("Ratio of the credential's expiration time when Spark should fetch new credentials.")

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -118,7 +118,6 @@ private[spark] class NettyBlockTransferService(
         }
       }
 
-      val maxRetries = transportConf.maxIORetries()
       if (maxRetries > 0) {
         // Note this Fetcher will correctly handle maxRetries == 0; we avoid it just in case there's
 

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -112,7 +112,7 @@ private[spark] class NettyBlockTransferService(
       val maxRetries = transportConf.maxIORetries()
       val blockFetchStarter = new RetryingBlockFetcher.BlockFetchStarter {
         override def createAndStart(blockIds: Array[String], listener: BlockFetchingListener) {
-          val client = clientFactory.createClient(host, port,maxRetries > 0)
+          val client = clientFactory.createClient(host, port, maxRetries > 0)
           new OneForOneBlockFetcher(client, appId, execId, blockIds, listener,
             transportConf, tempFileManager).start()
         }

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -109,9 +109,10 @@ private[spark] class NettyBlockTransferService(
       tempFileManager: DownloadFileManager): Unit = {
     logTrace(s"Fetch blocks from $host:$port (executor id $execId)")
     try {
+      val maxRetries = transportConf.maxIORetries()
       val blockFetchStarter = new RetryingBlockFetcher.BlockFetchStarter {
         override def createAndStart(blockIds: Array[String], listener: BlockFetchingListener) {
-          val client = clientFactory.createClient(host, port)
+          val client = clientFactory.createClient(host, port,maxRetries > 0)
           new OneForOneBlockFetcher(client, appId, execId, blockIds, listener,
             transportConf, tempFileManager).start()
         }
@@ -120,6 +121,7 @@ private[spark] class NettyBlockTransferService(
       val maxRetries = transportConf.maxIORetries()
       if (maxRetries > 0) {
         // Note this Fetcher will correctly handle maxRetries == 0; we avoid it just in case there's
+
         // a bug in this code. We should remove the if statement once we're sure of the stability.
         new RetryingBlockFetcher(transportConf, blockFetchStarter, blockIds, listener).start()
       } else {

--- a/core/src/main/scala/org/apache/spark/rpc/netty/Outbox.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/Outbox.scala
@@ -25,12 +25,12 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
-import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
+import org.apache.spark.network..{RpcResponseCallback, Transport}
 import org.apache.spark.rpc.{RpcAddress, RpcEnvStoppedException}
 
 private[netty] sealed trait OutboxMessage {
 
-  def sendWith(client: TransportClient): Unit
+  def sendWith(: Transport): Unit
 
   def onFailure(e: Throwable): Unit
 
@@ -39,8 +39,8 @@ private[netty] sealed trait OutboxMessage {
 private[netty] case class OneWayOutboxMessage(content: ByteBuffer) extends OutboxMessage
   with Logging {
 
-  override def sendWith(client: TransportClient): Unit = {
-    client.send(content)
+  override def sendWith(: Transport): Unit = {
+    .send(content)
   }
 
   override def onFailure(e: Throwable): Unit = {

--- a/core/src/main/scala/org/apache/spark/rpc/netty/Outbox.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/Outbox.scala
@@ -25,12 +25,12 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
-import org.apache.spark.network..{RpcResponseCallback, Transport}
+import org.apache.spark.network.client.{RpcResponseCallback, TransportClient}
 import org.apache.spark.rpc.{RpcAddress, RpcEnvStoppedException}
 
 private[netty] sealed trait OutboxMessage {
 
-  def sendWith(: Transport): Unit
+  def sendWith(client: TransportClient): Unit
 
   def onFailure(e: Throwable): Unit
 
@@ -39,8 +39,8 @@ private[netty] sealed trait OutboxMessage {
 private[netty] case class OneWayOutboxMessage(content: ByteBuffer) extends OutboxMessage
   with Logging {
 
-  override def sendWith(: Transport): Unit = {
-    .send(content)
+  override def sendWith(client: TransportClient): Unit = {
+    client.send(content)
   }
 
   override def onFailure(e: Throwable): Unit = {

--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -23,9 +23,9 @@ import java.sql.Connection
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import com.spotify.docker.client._
-import com.spotify.docker.client.exceptions.ImageNotFoundException
-import com.spotify.docker.client.messages.{ContainerConfig, HostConfig, PortBinding}
+import com.spotify.docker.._
+import com.spotify.docker..exceptions.ImageNotFoundException
+import com.spotify.docker..messages.{ContainerConfig, HostConfig, PortBinding}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.SpanSugar._
@@ -74,14 +74,14 @@ abstract class DockerJDBCIntegrationSuite
 
   val db: DatabaseOnDocker
 
-  private var docker: DockerClient = _
+  private var docker: Docker = _
   private var containerId: String = _
   protected var jdbcUrl: String = _
 
   override def beforeAll() {
     super.beforeAll()
     try {
-      docker = DefaultDockerClient.fromEnv.build()
+      docker = DefaultDocker.fromEnv.build()
       // Check that Docker is actually up
       try {
         docker.ping()

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -665,7 +665,7 @@ private[spark] class ApplicationMaster(args: ApplicationMasterArguments) extends
     var userArgs = args.userArgs
     if (args.primaryPyFile != null && args.primaryPyFile.endsWith(".py")) {
       // When running pyspark, the app is run using PythonRunner. The second argument is the list
-      // of files to add to PYTHONPATH, which Client.scala already handles, so it's empty.
+      // of files to add to PYTHONPATH, which C already handles, so it's empty.
       userArgs = Seq(args.primaryPyFile, "") ++ userArgs
     }
     if (args.primaryRFile != null && args.primaryRFile.endsWith(".R")) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -19,9 +19,8 @@ package org.apache.spark.scheduler.cluster
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.yarn.api.records.YarnApplicationState
-
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.deploy.yarn.{Client, ClientArguments,YarnAppReport}
+import org.apache.spark.deploy.yarn.{Client, ClientArguments, YarnAppReport}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.{config,Logging}
 import org.apache.spark.launcher.SparkAppHandle

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+// have been repair by spark offical
 package org.apache.spark.scheduler.cluster
 
 import scala.collection.mutable.ArrayBuffer
@@ -22,7 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.hadoop.yarn.api.records.YarnApplicationState
 
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.deploy.yarn.{Client, ClientArguments, YarnAppReport}
+import org.apache.spark.deploy.yarn.{Client, ClientArguments}
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.launcher.SparkAppHandle
@@ -33,10 +33,8 @@ private[spark] class YarnClientSchedulerBackend(
     sc: SparkContext)
   extends YarnSchedulerBackend(scheduler, sc)
   with Logging {
-
   private var client: Client = null
   private var monitorThread: MonitorThread = null
-
   /**
    * Create a Yarn client to submit an application to the ResourceManager.
    * This waits until the application is running.

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.yarn.api.records.YarnApplicationState
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.deploy.yarn.{Client, ClientArguments, YarnAppReport}
 import org.apache.spark.deploy.yarn.config._
-import org.apache.spark.internal.{config,Logging}
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.launcher.SparkAppHandle
 import org.apache.spark.scheduler.TaskSchedulerImpl
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -19,6 +19,7 @@ package org.apache.spark.scheduler.cluster
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.yarn.api.records.YarnApplicationState
+
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.deploy.yarn.{Client, ClientArguments, YarnAppReport}
 import org.apache.spark.deploy.yarn.config._

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// have been repair by spark offical
 package org.apache.spark.scheduler.cluster
 
 import scala.collection.mutable.ArrayBuffer
@@ -22,17 +21,19 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.hadoop.yarn.api.records.YarnApplicationState
 
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.deploy.yarn.{Client, ClientArguments}
+import org.apache.spark.deploy.yarn.{Client, ClientArguments,YarnAppReport}
 import org.apache.spark.deploy.yarn.config._
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{config,Logging}
 import org.apache.spark.launcher.SparkAppHandle
 import org.apache.spark.scheduler.TaskSchedulerImpl
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.
 
 private[spark] class YarnClientSchedulerBackend(
     scheduler: TaskSchedulerImpl,
     sc: SparkContext)
   extends YarnSchedulerBackend(scheduler, sc)
   with Logging {
+
   private var client: Client = null
   private var monitorThread: MonitorThread = null
   /**
@@ -62,6 +63,7 @@ private[spark] class YarnClientSchedulerBackend(
 
     monitorThread = asyncMonitorApplication()
     monitorThread.start()
+
   }
 
   /**
@@ -85,7 +87,6 @@ private[spark] class YarnClientSchedulerBackend(
         case Some(msg) =>
           logError(genericMessage)
           msg
-
         case None =>
           genericMessage
       }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnClientSchedulerBackend.scala
@@ -26,7 +26,7 @@ import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.{config,Logging}
 import org.apache.spark.launcher.SparkAppHandle
 import org.apache.spark.scheduler.TaskSchedulerImpl
-import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 
 private[spark] class YarnClientSchedulerBackend(
     scheduler: TaskSchedulerImpl,


### PR DESCRIPTION
What changes were proposed in this pull request?
the Spark AM relies on the initial set of tokens created by
the submission client to be able to talk to HDFS and other services that
require delegation tokens. This means that after those tokens expire, a
new AM will fail to start (e.g. when there is an application failure and
re-attempts are enabled).

Why are the changes needed?
To be able to re-use the code in the AMCredentialRenewal for the above
purposes

Does this PR introduce any user-facing change?
dev only

How was this patch tested?
new tests